### PR TITLE
a few ideas

### DIFF
--- a/SwiftRandom.xcodeproj/project.pbxproj
+++ b/SwiftRandom.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		70B072141B1D372D000A4593 /* SwiftRandom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 912784E81B18C85300DF7C27 /* SwiftRandom.swift */; };
 		912784D21B18C80900DF7C27 /* SwiftRandom.h in Headers */ = {isa = PBXBuildFile; fileRef = 912784D11B18C80900DF7C27 /* SwiftRandom.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		912784D81B18C80900DF7C27 /* SwiftRandom.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 912784CC1B18C80900DF7C27 /* SwiftRandom.framework */; };
 		912784E91B18C85300DF7C27 /* SwiftRandom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 912784E81B18C85300DF7C27 /* SwiftRandom.swift */; };
@@ -222,6 +223,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				70B072141B1D372D000A4593 /* SwiftRandom.swift in Sources */,
 				912784EB1B18C85E00DF7C27 /* SwiftRandomTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SwiftRandom/SwiftRandom.swift
+++ b/SwiftRandom/SwiftRandom.swift
@@ -18,9 +18,9 @@ Performs single Bernoulli trial with given probability of success.
 :returns: Success or failure as Bool. Returns nil if `probTrue` is not between 0 and 1.
 */
 
-func randBool(probTrue: Double) -> Bool? {
+func randBool(probTrue: Double) -> Bool {
     
-    return (probTrue >= 0 && probTrue <= 1) ? randCont() < probTrue : nil
+    return randCont() < probTrue
     
 }
 
@@ -33,9 +33,9 @@ Performs series of independent Bernoulli trials with given probability of succes
 :returns: Array of Bools. Returns nil if `probTrue` is not between 0 and 1.
 */
 
-func randBools(#probTrue: Double, length: Int) -> [Bool]? {
+func randBools(#probTrue: Double, length: Int) -> [Bool] {
     
-    return (probTrue >= 0 && probTrue <= 1) ? (0..<length).map { _ in randBool(probTrue)! } : nil
+    return(0..<length).map { _ in randBool(probTrue) }
     
 }
 
@@ -86,11 +86,9 @@ Generates array of independent pseudorandom variables from discrete uniform dist
 :returns: Array of independent pseudorandom variables from discrete uniform distribution with given boundaries. Returns nil if `max` <= `min` or `length` <= 0.
 */
 
-func randDiscs(#min: Int, max: Int, length: Int) -> [Int]? {
+func randDiscs(#min: Int, max: Int, length: Int) -> [Int] {
     
-    return max > min ?
-        
-        [Int](0..<length).map { _ in randDisc(min, max) } : nil
+    return [Int](0..<length).map { _ in randDisc(min, max) }
     
 }
 
@@ -156,9 +154,9 @@ Function uses inverse transform sampling.
 :returns: Single pseudorandom variable from exponential distribution with given rate. Returns nil if `rate` <= 0.
 */
 
-func randExp(#rate: Double) -> Double? {
+func randExp(#rate: Double) -> Double {
     
-    return rate > 0 ? -1.0/rate * log(randCont()) : nil
+    return -1.0/rate * log(randCont())
     
 }
 
@@ -172,9 +170,9 @@ Function uses inverse transform sampling.
 :returns: Array of independent pseudorandom variables from exponential distribution with given rate. Returns nil if `rate` <= 0.
 */
 
-func randomExps(#rate: Double, length: Int) -> [Double]? {
+func randomExps(#rate: Double, length: Int) -> [Double] {
     
-    return rate > 0 ? (0..<length).map { _ in randExp(rate: rate)! } : nil
+    return  (0..<length).map { _ in randExp(rate: rate) }
     
 }
 
@@ -190,16 +188,10 @@ Function uses Box-Muller transform.
 :returns: Single pseudorandom variable from normal distribution with given mean and standard deviation. Returns nil if `stdDev` <= 0.
 */
 
-func randNormal(#mean: Double, stdDev: Double) -> Double? {
+func randNormal(#mean: Double, stdDev: Double) -> Double {
     
-    return stdDev > 0 ?
-        
-            stdDev    *
-            sqrt(-2.0 * log(   randCont())   *
-            cos(  2.0 * M_PI * randCont()) ) +
-            mean :
-        
-        nil
+    return stdDev * sqrt(-2.0 * log(randCont()) * cos(M_2_PI * randCont())) + mean
+  
 }
 
 /**
@@ -213,10 +205,8 @@ Function uses Box-Muller transform.
 :returns: Array of independent pseudorandom variables from normal distribution with given mean and standard deviation. Returns nil if `stdDev` <= 0.
 */
 
-func randNormals(#mean: Double, stdDev: Double, length: Int) -> [Double]? {
-    
-    if stdDev <= 0 { return nil }
-    
+func randNormals(#mean: Double, stdDev: Double, length: Int) -> [Double] {
+  
     var randomSample = [Double]()
     
     while randomSample.count < length {
@@ -245,9 +235,9 @@ Generates random sample from given array - sampling with replacement.
 :returns: Array of length `length` with elements uniformly sampled from `items`. Returns nil for an empty array.
 */
 
-func sampleWithRepeats<T>(items: [T], length: Int) -> [T]? {
+func sampleWithRepeats<T>(items: [T], length: Int) -> [T] {
     
-    return items.isEmpty ? nil : (0..<length).map { _ in items[randDisc(items.count)] }
+    return (0..<length).map { _ in items[randDisc(items.count)] }
     
 }
 
@@ -260,13 +250,10 @@ Generates random sample from given array - sampling without replacement.
 :returns: Array of first `length` elements from shuffled array. Returns nil if  `length` > `items.count`.
 */
 
-func sampleWithoutRepeats<T>(var items: [T], length: Int) -> [T]? {
+func sampleWithoutRepeats<T>(var items: [T], length: Int) -> [T] {
     
-    return length > items.count ? nil :
-        
-        [Int]((items.count - length)..<items.count).reverse()
-            
-            .map { items.removeAtIndex(randDisc($0)) }
+    return [Int]((items.count - length)..<items.count).reverse()
+        .map { items.removeAtIndex(randDisc($0)) }
     
 }
 
@@ -281,9 +268,7 @@ Generates random sample from given array using probabilites given by the user.
 */
 
 func weightedSample<T>(items: [T], probs: [Double], length: Int) -> [T] {
-    
-    if items.isEmpty || items.count != probs.count { return [] }
-    
+        
     let factor = probs.reduce(0, combine: +) / Double(UInt32.max)
     
     let itemsAndProbs = zip(items, probs)

--- a/SwiftRandom/SwiftRandom.swift
+++ b/SwiftRandom/SwiftRandom.swift
@@ -252,7 +252,7 @@ Generates random sample from given array - sampling without replacement.
 
 func sampleWithoutRepeats<T>(var items: [T], length: Int) -> [T] {
     
-    return [Int]((items.count - length)..<items.count).reverse()
+    return [Int]((items.count + 1 - length)...items.count).reverse()
         .map { items.removeAtIndex(randDisc($0)) }
     
 }

--- a/SwiftRandom/SwiftRandom.swift
+++ b/SwiftRandom/SwiftRandom.swift
@@ -11,7 +11,7 @@ public struct SwiftRandom {
     
     :param: probTrue Probability of success.
     
-    :returns: Success or failure as Int: 1 or 0. Returns nil if `probabilityOfSuccess` is not between 0 and 1.
+    :returns: Success or failure as Bool. Returns nil if `probTrue` is not between 0 and 1.
     */
     
     public static func randBool(#probTrue: Double) -> Bool? {
@@ -30,7 +30,7 @@ public struct SwiftRandom {
     :param: probTrue Probability of success.
     :param: length Length of sample to generate.
     
-    :returns: Array of 1 and 0, which indicate successes and failures. Returns nil if `probabilityOfSuccess` is not between 0 and 1 or `sampleLength` <= 0.
+    :returns: Array of Bools. Returns nil if `probTrue` is not between 0 and 1.
     */
     
     public static func randBools(#probTrue: Double, length: Int) -> [Bool]? {
@@ -52,7 +52,7 @@ public struct SwiftRandom {
     
     :param: length Length of sample to generate.
     
-    :returns: Array of 1 and 0, which indicate heads and tails. Returns nil if `sampleLength` <= 0.
+    :returns: Array of Bools, which indicate heads and tails.
     */
     
     public static func randBools(length: Int) -> [Bool] {
@@ -85,7 +85,7 @@ public struct SwiftRandom {
     :param: max Right boundary (inclusive) of distribution.
     :param: length Length of sample to generate.
     
-    :returns: Array of independent pseudorandom variables from discrete uniform distribution with given boundaries. Returns nil if `max` <= `min` or `sampleLength` <= 0.
+    :returns: Array of independent pseudorandom variables from discrete uniform distribution with given boundaries. Returns nil if `max` <= `min` or `length` <= 0.
     */
     
     public static func randDouble(#min: Int, max: Int, length: Int) -> [Int]? {
@@ -126,7 +126,7 @@ public struct SwiftRandom {
     :param: max Right boundary of distribution.
     :param: length Length of sample to generate.
     
-    :returns: Array of independent pseudorandom variables from continuous uniform distribution with given boundaries. Returns nil if `max` <= `min` or `sampleLength` <= 0.
+    :returns: Array of independent pseudorandom variables from continuous uniform distribution with given boundaries. Returns nil if `max` <= `min`.
     */
     
     public static func randDoubles(#min: Double, max: Double, length: Int) -> [Double]? {
@@ -163,7 +163,7 @@ public struct SwiftRandom {
     :param: rate Rate parameter of exponential distribution.
     :param: length Length of sample to generate.
     
-    :returns: Array of independent pseudorandom variables from exponential distribution with given rate. Returns nil if `rate` <= 0 or `sampleLength` <= 0.
+    :returns: Array of independent pseudorandom variables from exponential distribution with given rate. Returns nil if `rate` <= 0.
     */
     
     public static func randomExps(#rate: Double, length: Int) -> [Double]? {
@@ -185,7 +185,7 @@ public struct SwiftRandom {
     :param: mean Mean of normal distribution.
     :param: stdDev Standard deviation of normal distribution.
     
-    :returns: Single pseudorandom variable from normal distribution with given mean and standard deviation. Returns nil if `standardDeviation` <= 0.
+    :returns: Single pseudorandom variable from normal distribution with given mean and standard deviation. Returns nil if `stdDev` <= 0.
     */
     
     public static func randNormal(#mean: Double, stdDev: Double) -> Double? {
@@ -204,7 +204,7 @@ public struct SwiftRandom {
     :param: stdDev Standard deviation of normal distribution.
     :param: length Length of sample to generate.
     
-    :returns: Array of independent pseudorandom variables from normal distribution with given mean and standard deviation. Returns nil if `standardDeviation` <= 0 or `sampleLength` <= 0.
+    :returns: Array of independent pseudorandom variables from normal distribution with given mean and standard deviation. Returns nil if `stdDev` <= 0.
     */
     
     public static func randNormals(#mean: Double, stdDev: Double, length: Int) -> [Double]? {
@@ -236,7 +236,7 @@ public struct SwiftRandom {
     :param: items The array of any type.
     :param: length The length of output sample.
     
-    :returns: Array of length `sampleLength` with elements uniformly sampled from `arrayToSampleFrom`. Returns nil for an empty array or `sampleLength` <= 0.
+    :returns: Array of length `length` with elements uniformly sampled from `items`. Returns nil for an empty array.
     */
     
     public static func sampleWithRepeats<T>(items: [T], length: Int) -> [T]? {
@@ -253,17 +253,16 @@ public struct SwiftRandom {
     
     /**
     Generates random sample from given array - sampling without replacement.
-    Function uses Fisher-Yates shuffling algorithm and returns Array of first `sampleLength` elements.
     
     :param: items The array of any type.
     :param: length The length of output sample.
     
-    :returns: Array of first `sampleLength` elements from shuffled array. Returns nil for an empty array or if `sampleLength` <= 0 or `sampleLength` > `arrayToSampleFrom.count`.
+    :returns: Array of first `length` elements from shuffled array. Returns nil if  `length` > `items.count`.
     */
     
     public static func sampleWithoutRepeats<T>(var items: [T], length: Int) -> [T]? {
         
-        return length >= items.count ? nil :
+        return length > items.count ? nil :
             
             [UInt32](UInt32(items.count - length)..<UInt32(items.count)).reverse()
                 .map { items.removeAtIndex(Int(arc4random_uniform($0))) }
@@ -277,7 +276,7 @@ public struct SwiftRandom {
     :param: probs The array of probabilities.
     :param: length The length of output sample.
     
-    :returns: Array of length `sampleLength` with elements sampled from `arrayToSampleFrom` with probabilites from `probabilities`.
+    :returns: Array of length `length` with elements sampled from `items` with probabilites from `probs`.
     */
     
     public static func weightedSample<T>(items: [T], probs: [Double], length: Int) -> [T] {

--- a/SwiftRandom/SwiftRandom.swift
+++ b/SwiftRandom/SwiftRandom.swift
@@ -9,7 +9,7 @@ public struct SwiftRandom {
     /**
     Performs single Bernoulli trial with given probability of success.
     
-    :param: probabilityOfSuccess Probability of success.
+    :param: probTrue Probability of success.
     
     :returns: Success or failure as Int: 1 or 0. Returns nil if `probabilityOfSuccess` is not between 0 and 1.
     */
@@ -27,13 +27,13 @@ public struct SwiftRandom {
     /**
     Performs series of independent Bernoulli trials with given probability of success.
     
-    :param: probabilityOfSuccess Probability of success.
-    :param: sampleLength Length of sample to generate.
+    :param: probTrue Probability of success.
+    :param: length Length of sample to generate.
     
     :returns: Array of 1 and 0, which indicate successes and failures. Returns nil if `probabilityOfSuccess` is not between 0 and 1 or `sampleLength` <= 0.
     */
     
-    public static func randBoolArray(#probTrue: Double, length: Int) -> [Bool]? {
+    public static func randBools(#probTrue: Double, length: Int) -> [Bool]? {
         
         return ClosedInterval<Double>(0, 1).contains(probTrue) ?
             
@@ -50,12 +50,12 @@ public struct SwiftRandom {
     /**
     Simulates symmetric coin tossing experiment.
     
-    :param: sampleLength Length of sample to generate.
+    :param: length Length of sample to generate.
     
     :returns: Array of 1 and 0, which indicate heads and tails. Returns nil if `sampleLength` <= 0.
     */
     
-    public static func randomCoinTossArray(length: Int) -> [Bool] {
+    public static func randBools(length: Int) -> [Bool] {
         
         return (0..<length).map{ (_: Int) -> Bool in arc4random_uniform(2) == 0 }
         
@@ -72,7 +72,7 @@ public struct SwiftRandom {
     :returns: Single pseudorandom variable from discrete uniform distribution with given boundaries. Returns nil if `max` <= `min`.
     */
     
-    public static func randomDiscreteUniform(#min: Int, max: Int) -> Int? {
+    public static func randInt(#min: Int, max: Int) -> Int? {
         
         return max > min ? Int(arc4random_uniform(UInt32(max - min + 1))) + min : nil
         
@@ -83,18 +83,18 @@ public struct SwiftRandom {
     
     :param: min Left boundary (inclusive) of distribution.
     :param: max Right boundary (inclusive) of distribution.
-    :param: sampleLength Length of sample to generate.
+    :param: length Length of sample to generate.
     
     :returns: Array of independent pseudorandom variables from discrete uniform distribution with given boundaries. Returns nil if `max` <= `min` or `sampleLength` <= 0.
     */
     
-    public static func randomDiscreteUniformArray(#min: Int, max: Int, length: Int) -> [Int]? {
+    public static func randDouble(#min: Int, max: Int, length: Int) -> [Int]? {
         
         return max > min ?
             
             [Int](0..<length).map {
             
-                (_: Int) -> Int in self.randomDiscreteUniform(min: min, max: max)!
+                (_: Int) -> Int in self.randInt(min: min, max: max)!
             
             } : nil
         
@@ -111,7 +111,7 @@ public struct SwiftRandom {
     :returns: Single pseudorandom variable from continuous uniform distribution with given boundaries. Returns nil if `max` <= `min`.
     */
     
-    public static func randomContinuousUniform(#min: Double, max: Double) -> Double? {
+    public static func randDouble(#min: Double, max: Double) -> Double? {
         
         return max > min ?
             
@@ -124,16 +124,16 @@ public struct SwiftRandom {
     
     :param: min Left boundary of distribution.
     :param: max Right boundary of distribution.
-    :param: sampleLength Length of sample to generate.
+    :param: length Length of sample to generate.
     
     :returns: Array of independent pseudorandom variables from continuous uniform distribution with given boundaries. Returns nil if `max` <= `min` or `sampleLength` <= 0.
     */
     
-    public static func randomContinuousUniformArray(#min: Double, max: Double, sampleLength: Int) -> [Double]? {
+    public static func randDoubles(#min: Double, max: Double, length: Int) -> [Double]? {
         
-        return max > min ? [Int](0..<sampleLength).map {
+        return max > min ? [Int](0..<length).map {
             
-            (_: Int) -> Double in self.randomContinuousUniform(min: min, max: max)!
+            (_: Int) -> Double in self.randDouble(min: min, max: max)!
             
             } : nil
         
@@ -150,9 +150,9 @@ public struct SwiftRandom {
     :returns: Single pseudorandom variable from exponential distribution with given rate. Returns nil if `rate` <= 0.
     */
     
-    public static func randomExpontential(#rate: Double) -> Double? {
+    public static func randExp(#rate: Double) -> Double? {
         
-        return rate > 0 ? -1.0/rate * log(randomContinuousUniform(min: 0, max: 1)!) : nil
+        return rate > 0 ? -1.0/rate * log(randDouble(min: 0, max: 1)!) : nil
         
     }
     
@@ -161,16 +161,16 @@ public struct SwiftRandom {
     Function uses inverse transform sampling.
     
     :param: rate Rate parameter of exponential distribution.
-    :param: sampleLength Length of sample to generate.
+    :param: length Length of sample to generate.
     
     :returns: Array of independent pseudorandom variables from exponential distribution with given rate. Returns nil if `rate` <= 0 or `sampleLength` <= 0.
     */
     
-    public static func randomExponentialArray(#rate: Double, sampleLength: Int) -> [Double]? {
+    public static func randomExps(#rate: Double, length: Int) -> [Double]? {
         
-        return rate > 0 ? (0..<sampleLength).map {
+        return rate > 0 ? (0..<length).map {
             
-            (_: Int) -> Double in self.randomExpontential(rate: rate)!
+            (_: Int) -> Double in self.randExp(rate: rate)!
             
             } : nil
         
@@ -183,15 +183,15 @@ public struct SwiftRandom {
     Function uses Box-Muller transform.
     
     :param: mean Mean of normal distribution.
-    :param: standardDeviation Standard deviation of normal distribution.
+    :param: stdDev Standard deviation of normal distribution.
     
     :returns: Single pseudorandom variable from normal distribution with given mean and standard deviation. Returns nil if `standardDeviation` <= 0.
     */
     
-    public static func randomNormal(#mean: Double, stdDev: Double) -> Double? {
+    public static func randNormal(#mean: Double, stdDev: Double) -> Double? {
         
-        let r2 = -2.0 * log(randomContinuousUniform(min: 0, max: 1)!)
-        let theta = 2.0 * M_PI * randomContinuousUniform(min: 0, max: 1)!
+        let r2 = -2.0 * log(randDouble(min: 0, max: 1)!)
+        let theta = 2.0 * M_PI * randDouble(min: 0, max: 1)!
         
         return stdDev > 0 ? stdDev * (sqrt(r2) * cos(theta)) + mean : nil
     }
@@ -201,13 +201,13 @@ public struct SwiftRandom {
     Function uses Box-Muller transform.
     
     :param: mean Mean of normal distribution.
-    :param: standardDeviation Standard deviation of normal distribution.
-    :param: sampleLength Length of sample to generate.
+    :param: stdDev Standard deviation of normal distribution.
+    :param: length Length of sample to generate.
     
     :returns: Array of independent pseudorandom variables from normal distribution with given mean and standard deviation. Returns nil if `standardDeviation` <= 0 or `sampleLength` <= 0.
     */
     
-    public static func randomNormalArray(#mean: Double, stdDev: Double, length: Int) -> [Double]? {
+    public static func randNormals(#mean: Double, stdDev: Double, length: Int) -> [Double]? {
         
         if stdDev <= 0 { return nil }
         
@@ -215,8 +215,8 @@ public struct SwiftRandom {
         
         while randomSample.count < length {
             
-            let r2 = -2.0 * log(self.randomContinuousUniform(min: 0, max: 1)!)
-            let theta = 2.0 * M_PI * self.randomContinuousUniform(min: 0, max: 1)!
+            let r2 = -2.0 * log(self.randDouble(min: 0, max: 1)!)
+            let theta = 2.0 * M_PI * self.randDouble(min: 0, max: 1)!
             
             randomSample.append(stdDev * (sqrt(r2) * cos(theta)) + mean)
             randomSample.append(stdDev * (sqrt(r2) * sin(theta)) + mean)
@@ -233,13 +233,13 @@ public struct SwiftRandom {
     /**
     Generates random sample from given array - sampling with replacement.
     
-    :param: arrayToSampleFrom The array of any type.
-    :param: sampleLength The length of output sample.
+    :param: items The array of any type.
+    :param: length The length of output sample.
     
     :returns: Array of length `sampleLength` with elements uniformly sampled from `arrayToSampleFrom`. Returns nil for an empty array or `sampleLength` <= 0.
     */
     
-    public static func samplingWithReplacementFromArray<T>(items: [T], length: Int) -> [T]? {
+    public static func sampleWithRepeats<T>(items: [T], length: Int) -> [T]? {
         
         return items.isEmpty ? nil :
             
@@ -255,13 +255,13 @@ public struct SwiftRandom {
     Generates random sample from given array - sampling without replacement.
     Function uses Fisher-Yates shuffling algorithm and returns Array of first `sampleLength` elements.
     
-    :param: arrayToSampleFrom The array of any type.
-    :param: sampleLength The length of output sample.
+    :param: items The array of any type.
+    :param: length The length of output sample.
     
     :returns: Array of first `sampleLength` elements from shuffled array. Returns nil for an empty array or if `sampleLength` <= 0 or `sampleLength` > `arrayToSampleFrom.count`.
     */
     
-    public static func samplingWithoutReplacementFromArray<T>(var items: [T], length: Int) -> [T]? {
+    public static func sampleWithoutRepeats<T>(var items: [T], length: Int) -> [T]? {
         
         return length >= items.count ? nil :
             
@@ -273,14 +273,14 @@ public struct SwiftRandom {
     /**
     Generates random sample from given array using probabilites given by the user.
     
-    :param: arrayToSampleFrom The array of any type.
-    :param: probabilities The array of probabilities.
-    :param: sampleLength The length of output sample.
+    :param: items The array of any type.
+    :param: probs The array of probabilities.
+    :param: length The length of output sample.
     
     :returns: Array of length `sampleLength` with elements sampled from `arrayToSampleFrom` with probabilites from `probabilities`.
     */
     
-    public static func samplingWithGivenProbabilities<T>(items: [T], probs: [Double], length: Int) -> [T] {
+    public static func weightedSample<T>(items: [T], probs: [Double], length: Int) -> [T] {
         
         let factor = probs.reduce(0, combine: +) / Double(UInt32.max)
         

--- a/SwiftRandom/SwiftRandom.swift
+++ b/SwiftRandom/SwiftRandom.swift
@@ -16,7 +16,7 @@ public struct SwiftRandom {
     
     public static func randBool(#probTrue: Double) -> Bool? {
         
-        return ClosedInterval<Double>(0, 1).contains(probTrue) ?
+        return (probTrue >= 0 && probTrue <= 1) ?
             
             Double(arc4random_uniform(UInt32.max - 1)) / Double(UInt32.max) < probTrue :
             
@@ -35,7 +35,7 @@ public struct SwiftRandom {
     
     public static func randBools(#probTrue: Double, length: Int) -> [Bool]? {
         
-        return ClosedInterval<Double>(0, 1).contains(probTrue) ?
+        return (probTrue >= 0 && probTrue <= 1) ?
             
             [Int](0..<length).map {
                 

--- a/SwiftRandomTests/SwiftRandomTests.swift
+++ b/SwiftRandomTests/SwiftRandomTests.swift
@@ -11,17 +11,7 @@ import SwiftRandom
 
 class SwiftRandomTests: XCTestCase {
     
-    func testUniformEqualParameters() {
-        let result = randCont(1.0, 1.0)
-        
-        XCTAssertEqual(1.0, result)
-    }
 
-    
-    func testNormal() {
-        let result = randNormals(mean: 0, 1, 11)
-        print(result)
-    }
     
 }
     

--- a/SwiftRandomTests/SwiftRandomTests.swift
+++ b/SwiftRandomTests/SwiftRandomTests.swift
@@ -12,25 +12,14 @@ import SwiftRandom
 class SwiftRandomTests: XCTestCase {
     
     func testUniformEqualParameters() {
-        let result = SwiftRandom.randomContinuousUniform(min: 1.0, max: 1.0)!
+        let result = randCont(1.0, 1.0)
         
         XCTAssertEqual(1.0, result)
     }
-    
-    func testUniformMaxSmallerThanMin() {
-        let result = SwiftRandom.randomContinuousUniform(min: 1, max: 0)
-        
-        XCTAssert(result == nil)
-    }
-    
-    func testUniformArray() {
-        let result = SwiftRandom.randomContinuousUniformArray(min: 0, max: 1, sampleLength: 0)
-        
-        XCTAssert(result == nil)
-    }
+
     
     func testNormal() {
-        let result = SwiftRandom.randomNormalArray(mean: 0, standardDeviation: 1, sampleLength: 11)
+        let result = randNormals(mean: 0, 1, 11)
         print(result)
     }
     


### PR DESCRIPTION
Maybe not so much error checking? If you check for errors within each function, that'll create a pretty big overhead (especially for, say functions like your single random number: if you check that `max > min` each time for that, about a quarter of the processor cycles could be spent on that check). However, if you remove the checks, and specify that max must be greater than min in the docs (this is how the standard library `Range` does it) then you allow the user to do their own error checking, or bypass it if they know that the arguments they're using will always work, saving them the overhead.

Also, optionals usually aren't used for error checking: they're usually used for things that can and do return `nil` in normal operations. Look at your array sampling functions, and checking if the length parameter is less than zero. Realistically, that's something that should never happen, no matter what. You don't really want your function to return nil in that case, you want it to crash, so you find the bug quickly and early.

The standard library `find()` function is a good example of something that returns an optional, instead of crashing. `find()` returns an optional because of the nature of what it does: if it doesn't find what you're looking for, it returns `nil`. This may be something that you want to happen. However, if there was some other error, some problem in the logic of what it was doing (say you passed it the wrong type), you don't want it to return `nil`, you want it to crash. The difference is that you want your function to crash for arguments it should _never_ get, but return `nil` for a failure that might be desirable.

Some of the errors you check for don't actually need to be checked: say the sampling with replacement function. Why does length have to be smaller than the array you're sampling from? Say I want to sample `3` from the array `[1, 2]`. Why can't you just return, say `[1, 1, 2]`? It makes sense for the function to do that. (However, It wouldn't make sense for the `samplingWithoutReplacement` function to allow this, for example) Also, your `samplingWithGivenProbabilities` function doesn't need its probabilities to add up to one: you can just total its probabilities, and use that as the factor for your random number generator from then on in.

I think your variable names are a little long, and your functions take too many named parameters. Making the names long makes it annoying to type, and it can take up a lot of space, making the code less readable. The extra information given in the names often isn't needed: look at `randomContinuousUniformArray` for example. Why does that have the word `Array` at the end? You know it's going to return an array - it's right there in the type signature. Same goes for `samplingWithReplacementFromArray`: you know that it's got to be `FromArray` without having it in the name, because it only accepts an Array as its argument. In fact, in a lot of places, you probably don't have to specify named parameters at all: since your docs are so thorough, every piece of information you need is just an alt-click away. Especially in the one-parameter functions.

You seem to do a lot of initialising arrays to `0.0`, and then looping through their count, and filling them. The functions like `map()`, `flatMap()`, etc., are more efficient: instead of doing initialise, loop, lookup, change, increment, you can do it in one.

I wouldn't use `0`s and `1`s in place of `Bool`s, if at all possible. It obfuscates the purpose, it's slower, and you're likely going to have to convert back to a `Bool` at some stage anyway.

I hope I didn't come across as negative:  I thought it was really cool. I had a lot of fun looking through it!  Most of the things I'm talking about here are taste-based, rather than hard and fast rules, anyway, so don't feel any obligation to change what you've written: if you disagree with anything I've said, ignore it! I'm no authority.

Thanks for the cool code!
